### PR TITLE
`upper` flag

### DIFF
--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -63,5 +63,10 @@ pub fn parser() -> ArgMatches {
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with("verify"),
         )
+        .arg(
+            arg!(-u --upper "Return a hash in uppercase")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with("verify"),
+        )
         .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
     let args = cli::parser::parser();
     let verify_with = args.get_one::<String>("verify");
     let is_plaintext = args.get_flag("plaintext");
+    let in_uppercase = args.get_flag("upper");
     let file = args.get_one::<String>("FILE").expect("Is required");
     let algorithms: Vec<&str> = args
         .get_raw("algorithms")
@@ -37,6 +38,6 @@ fn main() {
     if let Some(check) = verify_with {
         utils::checksum(Path::new(file), algorithms, check)
     } else {
-        utils::print_hashs(Path::new(file), algorithms, is_plaintext)
+        utils::print_hashs(Path::new(file), algorithms, is_plaintext, in_uppercase)
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,7 +19,7 @@ use checksums::{hash_file, Algorithm};
 use colored::Colorize;
 use std::{path::Path, str::FromStr};
 
-pub fn print_hashs(file: &Path, algorithms: Vec<&str>, plaintext: bool) {
+pub fn print_hashs(file: &Path, algorithms: Vec<&str>, plaintext: bool, in_uppercase: bool) {
     let file_name = file
         .file_name()
         .expect("Cannot get file name from file")
@@ -35,7 +35,11 @@ pub fn print_hashs(file: &Path, algorithms: Vec<&str>, plaintext: bool) {
             file,
             Algorithm::from_str(algorithm).expect("Is has been validated"),
         );
-
+        let hash = if !in_uppercase {
+            hash.to_ascii_lowercase()
+        } else {
+            hash
+        };
         if plaintext {
             println!("# {algorithm}\n{hash}  {file_name}",)
         } else {
@@ -58,7 +62,7 @@ pub fn checksum(file: &Path, algorithms: Vec<&str>, check_hash: &str) {
             file,
             Algorithm::from_str(algorithm).expect("Is has been validated"),
         )
-        .eq(check_hash)
+        .eq_ignore_ascii_case(check_hash)
         {
             println!(
                 "{} Found match with `{}`",


### PR DESCRIPTION
closes #3.
Add `upper` flag to print uppercase hash 